### PR TITLE
Fix kospel integration device discovery

### DIFF
--- a/custom_components/kospel/coordinator.py
+++ b/custom_components/kospel/coordinator.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .api import KospelAPI, KospelAPIError
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -67,7 +68,7 @@ class KospelDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = {
                 "status": status_data,
                 "settings": settings_data,
-                "last_update": self.hass.helpers.event.utcnow(),
+                "last_update": dt_util.utcnow(),
             }
             
             _LOGGER.debug("Successfully updated data: %s", data)


### PR DESCRIPTION
Fix "Device ID not discovered yet" error by implementing automatic device discovery and robust initialization.

The `_device_id` was previously only discovered during the config flow's connection test, not during the integration's actual setup. This caused API calls to fail as the device ID was `None` during initial data fetches. This PR ensures the device ID is discovered automatically when needed and during initial setup.

---

[Open in Web](https://www.cursor.com/agents?id=bc-32972846-5df6-4b03-a88b-122849fe9ef5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-32972846-5df6-4b03-a88b-122849fe9ef5)