### PR TITLE
Fix kospel integration device discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ ERROR (MainThread) [custom_components.kospel.api] Failed to get status: Device I
        custom_components.kospel: debug
    ```
 
+#### ❌ "AttributeError: type object 'SensorDeviceClass' has no attribute 'RUNNING'"
+
+This error occurred in older versions and has been fixed by converting the running status sensors to binary sensors.
+
+**Solution**: Update to version 0.1.2 or later. The water heating and heater running sensors are now properly implemented as binary sensors.
+
 #### 🔄 Integration Won't Initialize
 
 1. Remove and re-add the integration

--- a/custom_components/kospel/__init__.py
+++ b/custom_components/kospel/__init__.py
@@ -11,7 +11,7 @@ from .coordinator import KospelDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/kospel/binary_sensor.py
+++ b/custom_components/kospel/binary_sensor.py
@@ -1,0 +1,131 @@
+"""Binary sensor platform for Kospel Electric Heaters."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import KospelDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Kospel binary sensor entities from a config entry."""
+    coordinator: KospelDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    
+    entities = [
+        KospelWaterHeatingBinarySensor(coordinator, config_entry),
+        KospelHeaterRunningBinarySensor(coordinator, config_entry),
+    ]
+    async_add_entities(entities)
+
+
+class KospelBinarySensorBase(CoordinatorEntity[KospelDataUpdateCoordinator], BinarySensorEntity):
+    """Base class for Kospel binary sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+        sensor_type: str,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self._config_entry = config_entry
+        self._sensor_type = sensor_type
+        self._attr_unique_id = f"{config_entry.entry_id}_{sensor_type}"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "identifiers": {(DOMAIN, self._config_entry.entry_id)},
+            "name": f"Kospel Heater ({self.coordinator.host})",
+            "manufacturer": MANUFACTURER,
+            "model": "Electric Heater with C.MI",
+            "sw_version": "1.0",
+            "configuration_url": f"http://{self.coordinator.host}:{self.coordinator.port}",
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class KospelWaterHeatingBinarySensor(KospelBinarySensorBase):
+    """Binary sensor for water heating status."""
+
+    _attr_name = "Water Heating"
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the water heating binary sensor."""
+        super().__init__(coordinator, config_entry, "water_heating")
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if water heating is on."""
+        if not self.coordinator.data:
+            return None
+        
+        status = self.coordinator.data.get("status", {})
+        return status.get("water_heating", False)
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        if self.is_on:
+            return "mdi:water-thermometer"
+        return "mdi:water-thermometer-outline"
+
+
+class KospelHeaterRunningBinarySensor(KospelBinarySensorBase):
+    """Binary sensor for heater running status."""
+
+    _attr_name = "Heater Running"
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+
+    def __init__(
+        self,
+        coordinator: KospelDataUpdateCoordinator,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the heater running binary sensor."""
+        super().__init__(coordinator, config_entry, "heater_running")
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if heater is running."""
+        if not self.coordinator.data:
+            return None
+        
+        status = self.coordinator.data.get("status", {})
+        return status.get("heater_running", False)
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        if self.is_on:
+            return "mdi:heating-coil"
+        return "mdi:radiator-off"

--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/username/ha-kospel-integration/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/custom_components/kospel/sensor.py
+++ b/custom_components/kospel/sensor.py
@@ -35,8 +35,6 @@ async def async_setup_entry(
         KospelPowerSensor(coordinator, config_entry),
         KospelModeSensor(coordinator, config_entry),
         KospelWaterTemperatureSensor(coordinator, config_entry),
-        KospelWaterHeatingSensor(coordinator, config_entry),
-        KospelHeaterStatusSensor(coordinator, config_entry),
         KospelErrorCodeSensor(coordinator, config_entry),
     ]
     async_add_entities(entities)
@@ -205,76 +203,7 @@ class KospelWaterTemperatureSensor(KospelSensorBase):
         return status.get("water_temperature")
 
 
-class KospelWaterHeatingSensor(KospelSensorBase):
-    """Sensor for water heating status."""
 
-    _attr_name = "Water Heating"
-    _attr_icon = "mdi:water-thermometer"
-    _attr_device_class = SensorDeviceClass.RUNNING
-
-    def __init__(
-        self,
-        coordinator: KospelDataUpdateCoordinator,
-        config_entry: ConfigEntry,
-    ) -> None:
-        """Initialize the water heating sensor."""
-        super().__init__(coordinator, config_entry, "water_heating")
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the water heating status."""
-        if not self.coordinator.data:
-            return None
-        
-        status = self.coordinator.data.get("status", {})
-        return "on" if status.get("water_heating") else "off"
-
-    @property
-    def icon(self) -> str:
-        """Return the icon."""
-        if not self.coordinator.data:
-            return "mdi:water-thermometer-outline"
-        
-        status = self.coordinator.data.get("status", {})
-        if status.get("water_heating"):
-            return "mdi:water-thermometer"
-        return "mdi:water-thermometer-outline"
-
-
-class KospelHeaterStatusSensor(KospelSensorBase):
-    """Sensor for heater running status."""
-
-    _attr_name = "Heater Running"
-    _attr_icon = "mdi:heating-coil"
-    _attr_device_class = SensorDeviceClass.RUNNING
-
-    def __init__(
-        self,
-        coordinator: KospelDataUpdateCoordinator,
-        config_entry: ConfigEntry,
-    ) -> None:
-        """Initialize the heater status sensor."""
-        super().__init__(coordinator, config_entry, "heater_running")
-
-    @property
-    def native_value(self) -> str | None:
-        """Return the heater running status."""
-        if not self.coordinator.data:
-            return None
-        
-        status = self.coordinator.data.get("status", {})
-        return "on" if status.get("heater_running") else "off"
-
-    @property
-    def icon(self) -> str:
-        """Return the icon."""
-        if not self.coordinator.data:
-            return "mdi:heating-coil"
-        
-        status = self.coordinator.data.get("status", {})
-        if status.get("heater_running"):
-            return "mdi:heating-coil"
-        return "mdi:radiator-off"
 
 
 class KospelErrorCodeSensor(KospelSensorBase):


### PR DESCRIPTION
Convert water heating and heater running sensors to binary sensors to fix `AttributeError: SensorDeviceClass has no attribute 'RUNNING'`.

The `water_heating` and `heater_running` states are boolean (on/off) and were incorrectly implemented as regular sensors using `SensorDeviceClass.RUNNING`, which does not exist. This PR reclassifies them as binary sensors, which correctly use `BinarySensorDeviceClass.RUNNING`, aligning with Home Assistant's entity best practices.

---

[Open in Web](https://www.cursor.com/agents?id=bc-32972846-5df6-4b03-a88b-122849fe9ef5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-32972846-5df6-4b03-a88b-122849fe9ef5)