### PR TITLE
Fix EKD API device ID discovery using sessionDevice endpoint

### DIFF
--- a/custom_components/kospel/manifest.json
+++ b/custom_components/kospel/manifest.json
@@ -9,6 +9,6 @@
   "issue_tracker": "https://github.com/JanKrl/home-assistant-kospel/issues",
   "requirements": ["aiohttp"],
   "ssdp": [],
-      "version": "0.3.0",
+      "version": "0.3.1",
   "zeroconf": []
 }


### PR DESCRIPTION
- Added _discover_ekd_device_id() method to get correct device ID for EKD API
- EKD API now uses device ID from /api/sessionDevice instead of /api/dev
- Updated all EKD API calls to use _ekd_device_id instead of _device_id
- Added proper EKD device discovery to connection test and get_status

Fixes:
- Resolves 'API__EKD__WRONG_ID' error by using correct device ID format
- EKD API calls now match manufacturer's frontend implementation
- Proper device ID discovery for both legacy and EKD APIs

Based on analysis of manufacturer's getSessionDevice() function which uses:
- GET /api/sessionDevice with Accept: application/vnd.kospel.cmi-v1+json
- Returns sessionDevice ID needed for EKD API calls