### PR TITLE
feat: implement session management for EKD API

### DIFF
--- a/custom_components/kospel/const.py
+++ b/custom_components/kospel/const.py
@@ -36,6 +36,8 @@ MAX_WATER_TEMP = 60
 HTTP_TIMEOUT = 10
 API_DEV_ENDPOINT = "/api/dev"
 API_EKD_ENDPOINT = "/api/ekd/read"
+API_SELECT_MODULE_ENDPOINT = "/api/selectModule"
+API_SESSION_DEVICE_ENDPOINT = "/api/sessionDevice"
 
 # Entity names
 ENTITY_HEATER = "heater"


### PR DESCRIPTION
- Add _establish_session() method using selectModule endpoint
- Add _get_session_device_id() method using sessionDevice endpoint
- Update _ensure_connection() to establish session before EKD API calls
- Add API endpoint constants for better maintainability
- Implement proper session flow: device discovery → session establishment → get session device ID
- Remove backward compatibility concerns for cleaner implementation

This fixes issue #19 where EKD API returned 'API__EKD__WRONG_ID' error by properly establishing a session and getting the correct device ID.